### PR TITLE
Getting "ReferenceError: "ReactDOMServer" is not defined" when updating to lastet Om

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,9 @@
                  [org.clojure/clojurescript "1.7.170"]
                  [org.clojure/core.async "0.2.371"]
                  [org.omcljs/om "1.0.0-alpha22" :exclusions [cljsjs/react cljsjs/react-dom]]
-		 [cljsjs/react "0.14.3-0"]
-		 [cljsjs/react-dom "0.14.3-1"]
-		 [cljsjs/react-dom-server "0.14.3-0"]]
+                 [cljsjs/react "0.14.3-0"]
+                 [cljsjs/react-dom "0.14.3-1"]
+                 [cljsjs/react-dom-server "0.14.3-0"]]
 
   :plugins [[lein-cljsbuild "1.1.1"]]
 

--- a/project.clj
+++ b/project.clj
@@ -2,12 +2,15 @@
   :description "FIXME: write this!"
   :url "http://example.com/FIXME"
 
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-2173"]
-                 [org.clojure/core.async "0.1.267.0-0d7780-alpha"]
-                 [om "0.5.2-SNAPSHOT"]]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/clojurescript "1.7.170"]
+                 [org.clojure/core.async "0.2.371"]
+                 [org.omcljs/om "1.0.0-alpha22" :exclusions [cljsjs/react cljsjs/react-dom]]
+		 [cljsjs/react "0.14.3-0"]
+		 [cljsjs/react-dom "0.14.3-1"]
+		 [cljsjs/react-dom-server "0.14.3-0"]]
 
-  :plugins [[lein-cljsbuild "1.0.2"]]
+  :plugins [[lein-cljsbuild "1.1.1"]]
 
   :source-paths ["src"]
 


### PR DESCRIPTION
Hi,

I'm trying to upgrade to the latest Clojure/ClojureScript/Core.Async/Om.  I'm getting the following error when I run
jjs main.js

ReferenceError: "ReactDOMServer" is not defined

Any thoughts as to how I fix this?
Thanks,
Hugh
